### PR TITLE
fix dir symlink.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,8 +86,9 @@ type DotfilesConfig struct {
 
 // DirectoryMap represents a directory mapping from source to target
 type DirectoryMap struct {
-	Source string `toml:"source"` // Source directory relative to dotfiles repo (e.g., "macOS/claude")
-	Target string `toml:"target"` // Target directory relative to home (e.g., ".claude")
+	Source  string `toml:"source"`  // Source directory relative to dotfiles repo (e.g., "macOS/claude")
+	Target  string `toml:"target"`  // Target directory relative to home (e.g., ".claude")
+	Symlink *bool  `toml:"symlink"` // Per-directory symlink override (nil = use global setting)
 }
 
 // DefaultConfig returns the default configuration


### PR DESCRIPTION
  
https://github.com/yyYank/goodbye/issues/13


  問題: [[dotfiles.directories]] に symlink = true
  を指定しても、DirectoryMap 構造体に Symlink
  フィールドがなかったため、TOML
  パーサーがその値を無視していました。結果として、常にグローバル設定（デフォルト false =
  copy）が使われていました。

  修正 (2ファイル):

  1. internal/config/config.go: DirectoryMap 構造体に Symlink *bool フィールドを追加。*bool（ポインタ）にすることで、「未指定（nil → グローバル設定にフォールバック）」と「明示的にfalse」を区別できるようにしました。
  2. internal/dotfiles/import.go:
  ディレクトリ処理のループで、dirMap.Symlink
  が設定されていればそれを優先し、未設定ならグローバルの useSymlink にフォールバックするロジックを追加。dry-run 表示と実際のインポートの両方に適用されます。
  これにより、以下の設定で期待通り [symlink]
  と表示されるようになります：

  [[dotfiles.directories]]
    source = "claude/skills"
    target = ".claude/skills"
    symlink = true